### PR TITLE
feature(CRUDListService): Initial version

### DIFF
--- a/src/app/api-sdk/model/ApiWebsite.ts
+++ b/src/app/api-sdk/model/ApiWebsite.ts
@@ -1,5 +1,5 @@
 import { Company } from '../../model/Company';
-import { Id } from './Common';
+import { Entity, Id } from './Common';
 
 export enum ApiWebsiteKind {
   DEFAULT = 'DEFAULT',
@@ -8,8 +8,7 @@ export enum ApiWebsiteKind {
   EXCLUSIVE = 'EXCLUSIVE',
 }
 
-export interface ApiWebsite {
-  id: Id;
+export interface ApiWebsite extends Entity {
   creationDate: Date;
   host: string;
   companyId: Id;

--- a/src/app/api-sdk/model/Common.ts
+++ b/src/app/api-sdk/model/Common.ts
@@ -1,1 +1,5 @@
 export type Id = string;
+
+export interface Entity {
+  id: Id;
+}

--- a/src/app/services/CRUDListService.ts
+++ b/src/app/services/CRUDListService.ts
@@ -1,0 +1,161 @@
+import { Entity, Id } from '../api-sdk/model/Common';
+import { BehaviorSubject, Observable, throwError } from 'rxjs';
+import { ServiceUtils } from './service.utils';
+import { ApiError } from '../api-sdk/ApiClient';
+import { Index } from '../model/Common';
+import { catchError, map, mergeMap } from 'rxjs/operators';
+
+interface CRUDListMethods<T extends Entity, C = Partial<T>, U = Partial<T>> {
+  list?: () => Observable<T[]>;
+  create?: (c: C) => Observable<T>;
+  update?: (id: Id, u: U) => Observable<T>;
+  remove?: (id: Id) => Observable<void>;
+}
+
+export class CRUDListServiceNotImplementedError extends Error {
+  constructor(method: string) {
+    super(`[CRUDService] Method ${method} not implemented.`);
+  }
+}
+
+export abstract class CRUDListService<T extends Entity, C, U> {
+
+  constructor(
+    protected utils: ServiceUtils,
+    protected methods: CRUDListMethods<T, C, U>) {
+  }
+
+  protected source = new BehaviorSubject<T[] | undefined>(undefined);
+
+  protected _creating = false;
+  get creating() {
+    return this._creating;
+  }
+
+  protected _creatingError?: ApiError;
+  get creatingError() {
+    return this._creatingError;
+  }
+
+  protected _fetching = false;
+  get fetching() {
+    return this._fetching;
+  }
+
+  protected _fetchError?: ApiError;
+  get fetchError() {
+    return this._fetchError;
+  }
+
+  protected _updating = new Set<string>();
+  readonly updating = (id: Id) => this._updating.has(id);
+
+  protected _updateError: Index<ApiError> = {};
+  readonly updateError = (id: Id): ApiError => this._updateError[id];
+
+  protected _removing = new Set<string>();
+  readonly removing = (id: Id) => this._removing.has(id);
+
+  protected _removeError: Index<ApiError> = {};
+  readonly removeError = (id: Id): ApiError => this._removeError[id];
+
+  readonly create = (data: C): Observable<T> => {
+    if (!this.methods.create) {
+      throw new CRUDListServiceNotImplementedError(`create`);
+    }
+    return new Observable(_ => _.next()).pipe(
+      map(_ => {
+        this._creating = true;
+        this._creatingError = undefined;
+        return _;
+      }),
+      mergeMap(() => this.methods.create(data)),
+      map((createdWebsite => {
+        this._creating = false;
+        this.source.next([...(this.source.value ?? []), createdWebsite]);
+        return createdWebsite;
+      })),
+      catchError((err: ApiError) => {
+        this._creating = false;
+        this._creatingError = err;
+        return throwError(err);
+      }),
+    );
+  };
+
+  readonly list = ({ force = true, clean = true }: {force?: boolean, clean?: boolean} = {}): Observable<T[]> => {
+    if (!this.methods.list) {
+      throw new CRUDListServiceNotImplementedError(`list`);
+    }
+    if (this.source.value && !force) {
+      return this.source.asObservable() as Observable<T[]>;
+    }
+    if (clean) {
+      this.source.next(undefined);
+    }
+    return this.methods.list().pipe(
+      map(_ => {
+        this._fetching = true;
+        this._fetchError = undefined;
+        return _;
+      }),
+      mergeMap((websites: T[]) => {
+        this._fetching = false;
+        this.source.next(websites);
+        return this.source.asObservable() as Observable<T[]>;
+      }),
+      catchError((err: ApiError) => {
+        this._fetching = false;
+        this._fetchError = err;
+        return throwError(err);
+      }),
+    );
+  };
+
+  readonly update = (id: Id, data: U): Observable<T> => {
+    if (!this.methods.update) {
+      throw new CRUDListServiceNotImplementedError(`update`);
+    }
+    return new Observable(_ => _.next()).pipe(
+      map(_ => {
+        this._updating.add(id);
+        delete this._updateError[id];
+        return _;
+      }),
+      mergeMap(() => this.methods.update(id, data)),
+      map((updatedWebsite: T) => {
+        this.source.next((this.source.value ?? []).map((_: T) => _.id === id ? updatedWebsite : _));
+        this._updating.delete(id);
+        return updatedWebsite;
+      }),
+      catchError((err: ApiError) => {
+        this._updating.delete(id);
+        this._updateError[id] = err;
+        return throwError(err);
+      }),
+    );
+  };
+
+  readonly remove = (id: Id): Observable<void> => {
+    if (!this.methods.remove) {
+      throw new CRUDListServiceNotImplementedError(`remove`);
+    }
+    return new Observable(_ => _.next()).pipe(
+      map(_ => {
+        this._removing.add(id);
+        delete this._removeError[id];
+        return _;
+      }),
+      mergeMap(() => this.methods.remove(id)),
+      map(() => {
+        this.source.next((this.source.value ?? []).filter((_: T) => _.id !== id));
+        this._removing.delete(id);
+      }),
+      catchError((err: ApiError) => {
+        this._removing.delete(id);
+        this._removeError[id] = err;
+        return throwError(err);
+      }),
+    );
+  };
+}

--- a/src/app/services/helper/CRUDListService.ts
+++ b/src/app/services/helper/CRUDListService.ts
@@ -62,10 +62,10 @@ export abstract class CRUDListService<T extends Entity, C, U> extends ListServic
         return _;
       }),
       mergeMap(() => this.methods.create(data)),
-      map((createdWebsite => {
+      map((created => {
         this._creating = false;
-        this.source.next([...(this.source.value ?? []), createdWebsite]);
-        return createdWebsite;
+        this.source.next([...(this.source.value ?? []), created]);
+        return created;
       })),
       catchError((err: ApiError) => {
         this._creating = false;
@@ -86,10 +86,10 @@ export abstract class CRUDListService<T extends Entity, C, U> extends ListServic
         return _;
       }),
       mergeMap(() => this.methods.update(id, data)),
-      map((updatedWebsite: T) => {
-        this.source.next((this.source.value ?? []).map((_: T) => _.id === id ? updatedWebsite : _));
+      map((updated: T) => {
+        this.source.next((this.source.value ?? []).map((_: T) => _.id === id ? updated : _));
         this._updating.delete(id);
-        return updatedWebsite;
+        return updated;
       }),
       catchError((err: ApiError) => {
         this._updating.delete(id);

--- a/src/app/services/helper/CRUDListService.ts
+++ b/src/app/services/helper/CRUDListService.ts
@@ -7,7 +7,7 @@ import { catchError, map, mergeMap } from 'rxjs/operators';
 import { ListService } from './ListService';
 
 interface CRUDListMethods<T extends Entity, C = Partial<T>, U = Partial<T>> {
-  list: () => Observable<T[]>;
+  list: (...args: any[]) => Observable<T[]>;
   create?: (c: C) => Observable<T>;
   update?: (id: Id, u: U) => Observable<T>;
   remove?: (id: Id) => Observable<void>;

--- a/src/app/services/helper/ListService.ts
+++ b/src/app/services/helper/ListService.ts
@@ -1,0 +1,51 @@
+import { Entity } from '../../api-sdk/model/Common';
+import { BehaviorSubject, Observable, throwError } from 'rxjs';
+import { ServiceUtils } from '../service.utils';
+import { ApiError } from '../../api-sdk/ApiClient';
+import { catchError, map, mergeMap } from 'rxjs/operators';
+
+export abstract class ListService<T extends Entity> {
+
+  constructor(
+    protected utils: ServiceUtils,
+    protected listMethod: () => Observable<T[]>) {
+  }
+
+  protected source = new BehaviorSubject<T[] | undefined>(undefined);
+
+  protected _fetching = false;
+  get fetching() {
+    return this._fetching;
+  }
+
+  protected _fetchError?: ApiError;
+  get fetchError() {
+    return this._fetchError;
+  }
+
+  readonly list = ({ force = true, clean = true }: {force?: boolean, clean?: boolean} = {}): Observable<T[]> => {
+    if (this.source.value && !force) {
+      return this.source.asObservable() as Observable<T[]>;
+    }
+    if (clean) {
+      this.source.next(undefined);
+    }
+    return this.listMethod().pipe(
+      map(_ => {
+        this._fetching = true;
+        this._fetchError = undefined;
+        return _;
+      }),
+      mergeMap((websites: T[]) => {
+        this._fetching = false;
+        this.source.next(websites);
+        return this.source.asObservable() as Observable<T[]>;
+      }),
+      catchError((err: ApiError) => {
+        this._fetching = false;
+        this._fetchError = err;
+        return throwError(err);
+      }),
+    );
+  };
+}

--- a/src/app/services/helper/ListService.ts
+++ b/src/app/services/helper/ListService.ts
@@ -37,9 +37,9 @@ export abstract class ListService<T extends Entity> {
         return _;
       }),
       mergeMap(() => this.listMethod(...args)),
-      mergeMap((websites: T[]) => {
+      mergeMap((data: T[]) => {
         this._fetching = false;
-        this.source.next(websites);
+        this.source.next(data);
         return this.source.asObservable() as Observable<T[]>;
       }),
       catchError((err: ApiError) => {

--- a/src/app/services/website.service.ts
+++ b/src/app/services/website.service.ts
@@ -1,127 +1,32 @@
 import { Injectable } from '@angular/core';
 import { ServiceUtils } from './service.utils';
 import { catchError, map, mergeMap } from 'rxjs/operators';
-import { BehaviorSubject, Observable, throwError } from 'rxjs';
+import { Observable, throwError } from 'rxjs';
 import { ApiWebsite, ApiWebsiteCreate, ApiWebsiteUpdateCompany, ApiWebsiteWithCompany } from '../api-sdk/model/ApiWebsite';
 import { Id } from '../api-sdk/model/Common';
 import { ApiError } from '../api-sdk/ApiClient';
 import { Index } from '../model/Common';
+import { CRUDListService } from './CRUDListService';
 
 @Injectable({
   providedIn: 'root'
 })
-export class WebsiteService {
+export class WebsiteService extends CRUDListService<ApiWebsiteWithCompany, ApiWebsiteCreate, Partial<ApiWebsite>> {
 
-  constructor(
-    private utils: ServiceUtils,
-  ) {
+  constructor(protected utils: ServiceUtils,) {
+    super(utils, {
+      list: () => utils.getReportApiSdk().pipe(mergeMap(api => api.website.list())),
+      create: (c: ApiWebsiteCreate) => utils.getReportApiSdk().pipe(mergeMap(api => api.website.create(c))),
+      update: (id: Id, u: Partial<ApiWebsite>) => utils.getReportApiSdk().pipe(mergeMap(api => api.website.update(id, u))),
+      remove: (id: Id) => utils.getReportApiSdk().pipe(mergeMap(api => api.website.remove(id))),
+    });
   }
-
-  private source = new BehaviorSubject<ApiWebsiteWithCompany[] | undefined>(undefined);
-
-  private _creating = false;
-  get creating() {
-    return this._creating;
-  }
-
-  private _creatingError?: ApiError;
-  get creatingError() {
-    return this._creatingError;
-  }
-
-  private _fetching = false;
-  get fetching() {
-    return this._fetching;
-  }
-
-  private _fetchError?: ApiError;
-  get fetchError() {
-    return this._fetchError;
-  }
-
-  private _updating = new Set<string>();
-  updating = (id: string) => this._updating.has(id);
-
-  private _updateError: Index<ApiError> = {};
-  updateError = (id: string): ApiError => this._updateError[id];
 
   private _updateCompanyError: Index<ApiError> = {};
-  updateCompanyError = (id: string): ApiError => this._updateCompanyError[id];
+  readonly updateCompanyError = (id: string): ApiError => this._updateCompanyError[id];
 
   private _updatingCompany = new Set<string>();
-  updatingCompany = (id: string) => this._updatingCompany.has(id);
-
-  private _removing = new Set<string>();
-  removing = (id: string) => this._removing.has(id);
-
-  private _removeError: Index<ApiError> = {};
-  removeError = (id: string): ApiError => this._removeError[id];
-
-  readonly create = (website: ApiWebsiteCreate): Observable<ApiWebsiteWithCompany> => {
-    this._creating = true;
-    this._creatingError = undefined;
-    return this.utils.getReportApiSdk().pipe(
-      mergeMap(api => api.website.create(website)),
-      map((createdWebsite => {
-        this._creating = false;
-        this.source.next([...(this.source.value ?? []), createdWebsite]);
-        return createdWebsite;
-      })),
-      catchError((err: ApiError) => {
-        this._creating = false;
-        this._creatingError = err;
-        return throwError(err);
-      }),
-    );
-  };
-
-  readonly list = ({ force = true, clean = true }: {force?: boolean, clean?: boolean} = {}): Observable<ApiWebsiteWithCompany[]> => {
-    if (this.source.value && !force) {
-      return this.source.asObservable() as Observable<ApiWebsiteWithCompany[]>;
-    }
-    if (clean) {
-      this.source.next(undefined);
-    }
-    return this.utils.getReportApiSdk().pipe(
-      map(_ => {
-        this._fetching = true;
-        this._fetchError = undefined;
-        return _;
-      }),
-      mergeMap(api => api.website.list()),
-      mergeMap((websites: ApiWebsiteWithCompany[]) => {
-        this._fetching = false;
-        this.source.next(websites);
-        return this.source.asObservable() as Observable<ApiWebsiteWithCompany[]>;
-      }),
-      catchError((err: ApiError) => {
-        this._fetching = false;
-        this._fetchError = err;
-        return throwError(err);
-      }),
-    );
-  }
-
-  readonly update = (id: Id, website: Partial<ApiWebsite>): Observable<ApiWebsiteWithCompany> => {
-    return this.utils.getReportApiSdk().pipe(
-      map(_ => {
-        this._updating.add(id);
-        delete this._updateError[id];
-        return _;
-      }),
-      mergeMap(api => api.website.update(id, website)),
-      map((updatedWebsite: ApiWebsiteWithCompany) => {
-        this.source.next((this.source.value ?? []).map((_: ApiWebsiteWithCompany) => _.id === id ? updatedWebsite : _));
-        this._updating.delete(id);
-        return updatedWebsite;
-      }),
-      catchError((err: ApiError) => {
-        this._updating.delete(id);
-        this._updateError[id] = err;
-        return throwError(err);
-      }),
-    );
-  };
+  readonly updatingCompany = (id: string) => this._updatingCompany.has(id);
 
   readonly updateCompany = (id: Id, website: ApiWebsiteUpdateCompany): Observable<ApiWebsiteWithCompany> => {
     return this.utils.getReportApiSdk().pipe(
@@ -139,26 +44,6 @@ export class WebsiteService {
       catchError((err: ApiError) => {
         this._updatingCompany.delete(id);
         this._updateCompanyError[id] = err;
-        return throwError(err);
-      }),
-    );
-  };
-
-  readonly remove = (id: Id): Observable<void> => {
-    return this.utils.getReportApiSdk().pipe(
-      map(_ => {
-        this._removing.add(id);
-        delete this._removeError[id];
-        return _;
-      }),
-      mergeMap(api => api.website.remove(id)),
-      map(() => {
-        this.source.next((this.source.value ?? []).filter((_: ApiWebsiteWithCompany) => _.id !== id));
-        this._removing.delete(id);
-      }),
-      catchError((err: ApiError) => {
-        this._removing.delete(id);
-        this._removeError[id] = err;
         return throwError(err);
       }),
     );

--- a/src/app/services/website.service.ts
+++ b/src/app/services/website.service.ts
@@ -6,7 +6,7 @@ import { ApiWebsite, ApiWebsiteCreate, ApiWebsiteUpdateCompany, ApiWebsiteWithCo
 import { Id } from '../api-sdk/model/Common';
 import { ApiError } from '../api-sdk/ApiClient';
 import { Index } from '../model/Common';
-import { CRUDListService } from './CRUDListService';
+import { CRUDListService } from './helper/CRUDListService';
 
 @Injectable({
   providedIn: 'root'


### PR DESCRIPTION
Abstraction de la logique des services HTTP.

2 inconvénients. Tous les 2 liés aux limitations de l'implémentation par classe. J'ai vu qu'un service pouvait également être une fonction (https://stackoverflow.com/questions/45741480/how-to-use-angular-injectable-with-a-function-not-a-class). Dans ce cas on pourrait régler **1.** à coup sûr et très probablement **2.**, mais avec une implémentation moins naturelle.

1. On peut ne vouloir implémenter qu'un sous-ensemble des méthodes du CRUD. Dans ce cas le compilateur, même en strict mode, ne prévient pas que les autres méthodes ne sont pas implémentées.

2. Les services ne peuvent pas avoir plusieurs fetchs différents. Par exemple dans `anomaly.service.ts`, on a `getCategories`, `getAnomalies`, `getTags`, etc. Il faudrait les splitter dans des services distincts ou alors ne pas implémenter `ListService` dans ces cas là.